### PR TITLE
Draft: feat: add GraphQL schema extension to timeout long queries

### DIFF
--- a/local_intelligence_hub/settings.py
+++ b/local_intelligence_hub/settings.py
@@ -246,6 +246,8 @@ if DEBUG and HIDE_DEBUG_TOOLBAR is False:  # pragma: no cover
 
 # CK Section
 
+GRAPHQL_TIMEOUT_SECONDS=20
+
 one_hour = timedelta(hours=1)
 GQL_AUTH = GqlAuthSettings(
     JWT_EXPIRATION_DELTA=one_hour,


### PR DESCRIPTION
RFC: Do we need this? It's possible to create GraphQL queries that take so long to service they (a) cause other queries to be blocked and (b) can crash the backend server. Although in production we will have Django behind nginx, which can handle the timeout for us, this was a problem for us in development, as the GraphQL requests would fail more or less silently.

This adds an extension to the GraphQL handler that sets an expiry time for the request, and then checks if that time has passed before executing the next field `resolver`.

The downside is that this expiry time check happens before every field is resolved. However, this seems to be negligible compared to the time it takes to e.g. fetch data from the database or write it to the response.