### PR TITLE
add banner that requests feedback to marketing pages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install poetry
         run: curl -sSL https://install.python-poetry.org | python3 -
       - name: Install python dependencies
-        run: ~/.local/bin/poetry export --with dev -f requirements.txt --output requirements.txt && pip install -r requirements.txt
+        run: ~/.local/bin/poetry export --with dev --without-hashes -f requirements.txt --output requirements.txt && pip install -r requirements.txt
       - name: Start server
         run: gunicorn local_intelligence_hub.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 &
       - name: Start ngrok tunnelling

--- a/nextjs/src/app/(marketing)/feedback/page.tsx
+++ b/nextjs/src/app/(marketing)/feedback/page.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { Metadata } from 'next'
 
 
 const Feedback = () => {
@@ -70,8 +69,3 @@ const Feedback = () => {
 };
 
 export default Feedback;
-
-export const metadata: Metadata = {
-    title: 'Feedback',
-
-}

--- a/nextjs/src/app/(marketing)/feedback/page.tsx
+++ b/nextjs/src/app/(marketing)/feedback/page.tsx
@@ -1,0 +1,70 @@
+"use client"
+import { useState, useEffect } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+const Feedback = () => {
+    const posthog = usePostHog();
+    const [survey, setSurvey] = useState<Survey | null>(null);
+    const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
+    const [textAreaValue, setTextAreaValue] = useState('');
+    const [validationMessage, setValidationMessage] = useState('');
+
+    interface Survey {
+        id: string;
+        name: string;
+        type: string;
+    }
+
+    useEffect(() => {
+        posthog.getActiveMatchingSurveys((surveys) => {
+            const firstSurvey = surveys.find(survey => survey.type === 'api');
+            if (firstSurvey) {
+                setSurvey(firstSurvey);
+                posthog.capture("survey shown", {
+                    $survey_id: firstSurvey.id,
+                    $survey_name: firstSurvey.name
+                });
+            }
+        });
+    }, []);
+
+    const handleTextAreaChange = (event: { target: { value: string }; }) => {
+        setTextAreaValue(event.target.value);
+        if (validationMessage) setValidationMessage('');
+    };
+
+    const submitFeedback = () => {
+        if (survey && textAreaValue.trim()) {
+            posthog.capture("survey sent", {
+                $survey_id: survey.id,
+                $survey_name: survey.name,
+                $survey_response: textAreaValue
+            });
+            setTextAreaValue('');
+            setFeedbackSubmitted(true);
+        } else {
+            setValidationMessage("This field can't be blank.");
+        }
+    };
+
+    return (
+        <div className='max-w-prose'>
+            <h1 className='text-hLg font-IBMPlexSans mb-4'>Submit feedback on Mapped</h1>
+            {!feedbackSubmitted ? (
+                <>
+                    <Textarea value={textAreaValue} onChange={handleTextAreaChange} className='mb-2 bg-white text-black'></Textarea>
+                    {validationMessage && <div className='mb-2 text-white'>{validationMessage}</div>}
+                    <Button onClick={submitFeedback} variant="reverse" size='sm'>
+                        Send feedback
+                    </Button>
+                </>
+            ) : (
+                <p>Thanks for submitting your feedback!</p>
+            )}
+        </div>
+    );
+};
+
+export default Feedback;

--- a/nextjs/src/app/(marketing)/feedback/page.tsx
+++ b/nextjs/src/app/(marketing)/feedback/page.tsx
@@ -3,6 +3,8 @@ import { useState, useEffect } from 'react';
 import { usePostHog } from 'posthog-js/react';
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import { Metadata } from 'next'
+
 
 const Feedback = () => {
     const posthog = usePostHog();
@@ -68,3 +70,8 @@ const Feedback = () => {
 };
 
 export default Feedback;
+
+export const metadata: Metadata = {
+    title: 'Feedback',
+
+}

--- a/nextjs/src/app/(marketing)/layout.tsx
+++ b/nextjs/src/app/(marketing)/layout.tsx
@@ -18,9 +18,9 @@ export default async function Layout({
   return (
     <div className='flex flex-col min-h-dvh'>
       <AreaPattern />
-      <main className="p-4 relative">
-      <FeedbackBanner/>
       <Navbar isLoggedIn={isLoggedIn} />
+      <FeedbackBanner/>
+      <main className="p-4 relative">
         {children}
       </main>
       <Toaster />

--- a/nextjs/src/app/(marketing)/layout.tsx
+++ b/nextjs/src/app/(marketing)/layout.tsx
@@ -5,6 +5,7 @@ import Navbar from "@/components/navbar";
 import PreFooter from "@/components/pre-footer";
 import { useAuth } from "@/hooks/auth";
 import { Toaster } from "sonner";
+import FeedbackBanner from "@/components/marketing/FeedbackBanner";
 
 export default async function Layout({
   children,
@@ -17,11 +18,11 @@ export default async function Layout({
   return (
     <div className='flex flex-col min-h-dvh'>
       <AreaPattern />
-      <Navbar isLoggedIn={isLoggedIn} />
       <main className="p-4 relative">
+      <FeedbackBanner/>
+      <Navbar isLoggedIn={isLoggedIn} />
         {children}
       </main>
-
       <Toaster />
       <div className='flex flex-col gap-4 mt-auto mx-4'>
         {!isLoggedIn && <SignUp />}

--- a/nextjs/src/app/(marketing)/layout.tsx
+++ b/nextjs/src/app/(marketing)/layout.tsx
@@ -18,8 +18,9 @@ export default async function Layout({
   return (
     <div className='flex flex-col min-h-dvh'>
       <AreaPattern />
-      <Navbar isLoggedIn={isLoggedIn} />
       <FeedbackBanner/>
+      <Navbar isLoggedIn={isLoggedIn} />
+    
       <main className="p-4 relative">
         {children}
       </main>

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -71,6 +71,8 @@
     --accent: var(--meep-gray-600);
     --accent-foreground: var(--meep-gray-200);
     --border: 0, 0%, 100%, 0.32;
+    --yellow: 44, 99%, 62%;
+    --dark-secondary: 220, 25%, 16%;
 
     --brand: 222, 69%, 65%;
 

--- a/nextjs/src/components/marketing/FeedbackBanner.tsx
+++ b/nextjs/src/components/marketing/FeedbackBanner.tsx
@@ -58,7 +58,7 @@ const FeedbackBanner = () => {
     if (!showBanner) return null;
 
     return (
-        <header className="absolute top-0 left-0 right-0 bg-brandBlue z-20 p-4 flex flex-col gap-4">
+        <div className="absolute top-0 left-0 right-0 bg-brandBlue z-20 p-4 flex flex-col gap-4">
             <div className="flex justify-between">
                 <div><h3 className="text-hLg">Alpha software</h3>
                     <p>This is a rapidly changing prototype</p></div>
@@ -99,7 +99,7 @@ const FeedbackBanner = () => {
                     <div>Thanks for submitting your feedback</div>
                 )}
             </div>
-        </header >
+        </div >
     );
 };
 

--- a/nextjs/src/components/marketing/FeedbackBanner.tsx
+++ b/nextjs/src/components/marketing/FeedbackBanner.tsx
@@ -1,110 +1,14 @@
-"use client"
-import { useState, useEffect, SetStateAction } from 'react';
-import { usePostHog } from 'posthog-js/react';
-import { Textarea } from "@/components/ui/textarea";
+
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
 const FeedbackBanner = () => {
-    const posthog = usePostHog();
-    const [survey, setSurvey] = useState<Survey | null>(null);
-    const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
-    const [showTextArea, setShowTextArea] = useState(false);
-    const [textAreaValue, setTextAreaValue] = useState('');
-    const [showBanner, setShowBanner] = useState(true);
-    const [validationMessage, setValidationMessage] = useState('');
-
-    interface Survey {
-        id: string;
-        name: string;
-        type: string;
-    }
-
-    useEffect(() => {
-        posthog.getActiveMatchingSurveys((surveys) => {
-            const firstSurvey = surveys.find(survey => survey.type === 'api');
-            if (firstSurvey) {
-                setSurvey(firstSurvey);
-                posthog.capture("survey shown", {
-                    $survey_id: firstSurvey.id,
-                    $survey_name: firstSurvey.name
-                });
-            }
-        });
-    }, []);
-
-    const handleTextAreaChange = (event: { target: { value: SetStateAction<string>; }; }) => {
-        setTextAreaValue(event.target.value);
-        if (validationMessage) setValidationMessage('');
-    };
-
-    const submitFeedback = () => {
-        if (survey && textAreaValue.trim()) {
-            posthog.capture("survey sent", {
-                $survey_id: survey.id,
-                $survey_name: survey.name,
-                $survey_response: textAreaValue
-            });
-            setTextAreaValue('');
-            setFeedbackSubmitted(true);
-            setShowTextArea(false);
-        } else {
-            setValidationMessage("This field can't be blank.");
-        }
-    };
-
-    const closeBanner = () => setShowBanner(false);
-
-    if (!showBanner) return null;
 
     return (
-        <div className="absolute top-0 left-0 right-0 bg-brandBlue z-20 p-4 flex flex-col gap-4">
-            <div className="flex justify-between">
-                <div><h3 className="text-hLg">Alpha software</h3>
-                    <p>This is a rapidly changing prototype</p></div>
-                <svg onClick={closeBanner} xmlns="http://www.w3.org/2000/svg" width="33" height="36" viewBox="0 0 33 36" fill="none" style={{ cursor: 'pointer' }}>
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M16.2804 2.29877C16.5732 2.00587 16.5732 1.53099 16.2804 1.23809C15.9875 0.94519 15.5126 0.94519 15.2197 1.23809L8.25 8.20788L1.2803 1.23809C0.987401 0.94519 0.512524 0.94519 0.219624 1.23809C-0.0732756 1.53099 -0.0732756 2.00587 0.219624 2.29877L7.18937 9.26852L0.219624 16.2383C-0.0732756 16.5312 -0.0732756 17.006 0.219624 17.2989C0.512524 17.5918 0.987401 17.5918 1.2803 17.2989L8.25 10.3292L15.2197 17.2989C15.5126 17.5918 15.9875 17.5918 16.2804 17.2989C16.5732 17.006 16.5732 16.5312 16.2804 16.2383L9.31065 9.26852L16.2804 2.29877Z" fill="white" />
-                </svg>
-            </div>
-            <div className="max-w-prose">
-                <div className="flex flex-col gap-4 mb-4">
-                    <div>
-                        <Button variant="reverse" size='sm'> <Link
-                            className=""
-                            href="/signup"
-                        >
-                            Join the waitlist
-                        </Link>
-                        </Button>
-                    </div>
-                    <div>
-                        <Button variant="reverse" size='sm'> <Link
-                            className=""
-                            href="https://mapped.commonknowledge.coop/"
-                        >
-                            Mapped v.1
-                        </Link></Button>
-                    </div>
-                </div>
-                {!feedbackSubmitted ? (
-                    <div>
-                        {showTextArea && survey ? (
-                            <div>
-                                <Textarea value={textAreaValue} onChange={handleTextAreaChange} className='mb-2'></Textarea>
-                                {validationMessage && <div className='mb-2'>{validationMessage}</div>}
-                                <Button onClick={submitFeedback} variant="reverse" size='sm'>
-                                    Send feedback
-                                </Button>
-                            </div>
-                        ) : (
-                            <Button onClick={() => setShowTextArea(true)} variant="reverse" size='sm'>Leave feedback on Mapped</Button>
-                        )}
-                    </div>
-                ) : (
-                    <div>Thanks for submitting your feedback</div>
-                )}
-            </div>
-        </div >
+        <div className="bg-yellow p-xs flex justify-between items-center">
+            <p className="text-darkSecondary text-[17px] leading-[150%]">Mapped is currently in alpha. <Link className="underline" href="/about">Learn more about the project</Link> or <Link className="underline" href="https://mapped.commonknowledge.coop/">explore the previous version.</Link></p>
+            <Button className="bg-darkSecondary text-white text-labelLg py-[12px] hover:bg-darkSecondary"> <Link href="">Submit feedback</Link></Button>
+        </div>
     );
 };
 

--- a/nextjs/src/components/marketing/FeedbackBanner.tsx
+++ b/nextjs/src/components/marketing/FeedbackBanner.tsx
@@ -7,7 +7,7 @@ const FeedbackBanner = () => {
     return (
         <div className="bg-yellow p-xs flex justify-between items-center">
             <p className="text-darkSecondary text-[17px] leading-[150%]">Mapped is currently in alpha. <Link className="underline" href="/about">Learn more about the project</Link> or <Link className="underline" href="https://mapped.commonknowledge.coop/">explore the previous version.</Link></p>
-            <Button className="bg-darkSecondary text-white text-labelLg py-[12px] hover:bg-darkSecondary"> <Link href="">Submit feedback</Link></Button>
+            <Button className="bg-darkSecondary text-white text-labelLg py-[12px] hover:bg-darkSecondary"> <Link href="/feedback">Submit feedback</Link></Button>
         </div>
     );
 };

--- a/nextjs/src/components/marketing/FeedbackBanner.tsx
+++ b/nextjs/src/components/marketing/FeedbackBanner.tsx
@@ -1,0 +1,106 @@
+"use client"
+import { useState, useEffect, SetStateAction } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+const FeedbackBanner = () => {
+    const posthog = usePostHog();
+    const [survey, setSurvey] = useState<Survey | null>(null);
+    const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
+    const [showTextArea, setShowTextArea] = useState(false);
+    const [textAreaValue, setTextAreaValue] = useState('');
+    const [showBanner, setShowBanner] = useState(true);
+    const [validationMessage, setValidationMessage] = useState('');
+
+    interface Survey {
+        id: string;
+        name: string;
+        type: string;
+    }
+
+    useEffect(() => {
+        posthog.getActiveMatchingSurveys((surveys) => {
+            const firstSurvey = surveys.find(survey => survey.type === 'api');
+            if (firstSurvey) {
+                setSurvey(firstSurvey);
+                posthog.capture("survey shown", {
+                    $survey_id: firstSurvey.id,
+                    $survey_name: firstSurvey.name
+                });
+            }
+        });
+    }, []);
+
+    const handleTextAreaChange = (event: { target: { value: SetStateAction<string>; }; }) => {
+        setTextAreaValue(event.target.value);
+        if (validationMessage) setValidationMessage('');
+    };
+
+    const submitFeedback = () => {
+        if (survey && textAreaValue.trim()) {
+            posthog.capture("survey sent", {
+                $survey_id: survey.id,
+                $survey_name: survey.name,
+                $survey_response: textAreaValue
+            });
+            setTextAreaValue('');
+            setFeedbackSubmitted(true);
+            setShowTextArea(false);
+        } else {
+            setValidationMessage("This field can't be blank.");
+        }
+    };
+
+    const closeBanner = () => setShowBanner(false);
+
+    if (!showBanner) return null;
+
+    return (
+        <header className="absolute top-0 left-0 right-0 bg-brandBlue z-20 p-4 flex flex-col gap-4">
+            <div className="flex justify-between">
+                <div><h3 className="text-hLg">Alpha software</h3>
+                    <p>This is a rapidly changing prototype</p></div>
+                <svg onClick={closeBanner} xmlns="http://www.w3.org/2000/svg" width="33" height="36" viewBox="0 0 33 36" fill="none" style={{ cursor: 'pointer' }}>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M16.2804 2.29877C16.5732 2.00587 16.5732 1.53099 16.2804 1.23809C15.9875 0.94519 15.5126 0.94519 15.2197 1.23809L8.25 8.20788L1.2803 1.23809C0.987401 0.94519 0.512524 0.94519 0.219624 1.23809C-0.0732756 1.53099 -0.0732756 2.00587 0.219624 2.29877L7.18937 9.26852L0.219624 16.2383C-0.0732756 16.5312 -0.0732756 17.006 0.219624 17.2989C0.512524 17.5918 0.987401 17.5918 1.2803 17.2989L8.25 10.3292L15.2197 17.2989C15.5126 17.5918 15.9875 17.5918 16.2804 17.2989C16.5732 17.006 16.5732 16.5312 16.2804 16.2383L9.31065 9.26852L16.2804 2.29877Z" fill="white" />
+                </svg>
+                </div>
+            <div className="max-w-prose">
+                <div className="flex flex-col gap-2 mb-4">
+                    <Link
+                        className=""
+                        href="/signup"
+                    >
+                        Join the waitlist
+                    </Link>
+                    <Link
+                        className=""
+                        href="https://mapped.commonknowledge.coop/"
+                    >
+                        Mapped v.1
+                    </Link>
+                </div>
+                {!feedbackSubmitted ? (
+                    <div>
+                        {showTextArea && survey ? (
+                            <div>
+                                <Textarea value={textAreaValue} onChange={handleTextAreaChange} className='mb-2'></Textarea>
+                                {validationMessage && <div className='mb-2'>{validationMessage}</div>}
+                                <Button onClick={submitFeedback} variant="reverse" size='sm'>
+                                    Send feedback
+                                </Button>
+                            </div>
+                        ) : (
+                            <Button onClick={() => setShowTextArea(true)} variant="reverse" size='sm'>Leave feedback on Mapped</Button>
+                        )}
+                    </div>
+                ) : (
+                    <div>Thanks for submitting your feedback</div>
+                )}
+            </div>
+        </header >
+    );
+};
+
+export default FeedbackBanner;

--- a/nextjs/src/components/marketing/FeedbackBanner.tsx
+++ b/nextjs/src/components/marketing/FeedbackBanner.tsx
@@ -65,21 +65,26 @@ const FeedbackBanner = () => {
                 <svg onClick={closeBanner} xmlns="http://www.w3.org/2000/svg" width="33" height="36" viewBox="0 0 33 36" fill="none" style={{ cursor: 'pointer' }}>
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M16.2804 2.29877C16.5732 2.00587 16.5732 1.53099 16.2804 1.23809C15.9875 0.94519 15.5126 0.94519 15.2197 1.23809L8.25 8.20788L1.2803 1.23809C0.987401 0.94519 0.512524 0.94519 0.219624 1.23809C-0.0732756 1.53099 -0.0732756 2.00587 0.219624 2.29877L7.18937 9.26852L0.219624 16.2383C-0.0732756 16.5312 -0.0732756 17.006 0.219624 17.2989C0.512524 17.5918 0.987401 17.5918 1.2803 17.2989L8.25 10.3292L15.2197 17.2989C15.5126 17.5918 15.9875 17.5918 16.2804 17.2989C16.5732 17.006 16.5732 16.5312 16.2804 16.2383L9.31065 9.26852L16.2804 2.29877Z" fill="white" />
                 </svg>
-                </div>
+            </div>
             <div className="max-w-prose">
-                <div className="flex flex-col gap-2 mb-4">
-                    <Link
-                        className=""
-                        href="/signup"
-                    >
-                        Join the waitlist
-                    </Link>
-                    <Link
-                        className=""
-                        href="https://mapped.commonknowledge.coop/"
-                    >
-                        Mapped v.1
-                    </Link>
+                <div className="flex flex-col gap-4 mb-4">
+                    <div>
+                        <Button variant="reverse" size='sm'> <Link
+                            className=""
+                            href="/signup"
+                        >
+                            Join the waitlist
+                        </Link>
+                        </Button>
+                    </div>
+                    <div>
+                        <Button variant="reverse" size='sm'> <Link
+                            className=""
+                            href="https://mapped.commonknowledge.coop/"
+                        >
+                            Mapped v.1
+                        </Link></Button>
+                    </div>
                 </div>
                 {!feedbackSubmitted ? (
                     <div>

--- a/nextjs/tailwind.config.ts
+++ b/nextjs/tailwind.config.ts
@@ -128,6 +128,8 @@ const config = {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
+        yellow: "hsl(var(--yellow))",
+        darkSecondary:  "hsl(var(--dark-secondary))",
         background: {
           DEFAULT: "hsl(var(--meepGray-800))",
           secondary: "hsl(var(--meepGray-700))",


### PR DESCRIPTION
## Description
This PR adds a banner that displays a feedback form that submits feedback to a Posthog survey
It also has links to Mapped v1 and the about oage

## Motivation and Context
Addresses issue [MEEP-266](https://linear.app/commonknowledge/issue/MEEP-266/add-a-test-software-banner-with-a-feedback-request-button)

## How Can It Be Tested?
Download the branch and run locally 
Navigate to home page and observe the banner on page load
Click on submit feedback button
Fill out the feedback form
Navigate to Posthog and observe the response under the survey
https://us.posthog.com/project/19510/surveys/018ebe3a-d763-0000-a3b2-aac0beec82fa

## How Will This Be Deployed?
Standard continuous deployment

## Screenshots (if appropriate):

![Untitled1](https://github.com/commonknowledge/meep-intelligence-hub/assets/43313455/03422efe-6cdb-4c89-b9ee-22d6b7aaed31)

![Untitled2](https://github.com/commonknowledge/meep-intelligence-hub/assets/43313455/df378f1e-0211-4138-b5c9-3c3e46357ceb)

![Untitled3](https://github.com/commonknowledge/meep-intelligence-hub/assets/43313455/934b2137-41e0-4927-be2f-f86b1c4ba4af)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
