### PR TITLE
Add nicer default name to reports

### DIFF
--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -148,20 +148,20 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
     existing_reports = model_types.Report.get_queryset(
         models.Report.objects.get_queryset(), info
     ).exists()
-    
+
     map_report = create_with_computed_args(
         models.MapReport,
         info,
         data,
         computed_args=lambda info, data, model: {
             "organisation": get_or_create_organisation_for_source(info, data),
-            "slug": data.slug or slugify(data.name), 
-            "name": "Type your report name here"  # Default name for reports 
+            "slug": data.slug or slugify(data.name),
+            "name": "Type your report name here",  # Default name for reports
         },
     )
     if existing_reports:
         return map_report
-    
+
     # If this is the first report, add the user's first member list to it
     member_list = (
         model_types.ExternalDataSource.get_queryset(
@@ -183,6 +183,7 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
         ]
     map_report.save()
     return map_report
+
 
 def get_or_create_organisation_for_source(info: Info, data: any):
     if data.organisation:

--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -181,7 +181,7 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
                 "visible": True,
             }
         ]
-    map_report.save()
+        map_report.save()
     return map_report
 
 

--- a/hub/graphql/mutations.py
+++ b/hub/graphql/mutations.py
@@ -148,17 +148,20 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
     existing_reports = model_types.Report.get_queryset(
         models.Report.objects.get_queryset(), info
     ).exists()
+    
     map_report = create_with_computed_args(
         models.MapReport,
         info,
         data,
         computed_args=lambda info, data, model: {
             "organisation": get_or_create_organisation_for_source(info, data),
-            "slug": data.slug or slugify(data.name),
+            "slug": data.slug or slugify(data.name), 
+            "name": "Type your report name here"  # Default name for reports 
         },
     )
     if existing_reports:
         return map_report
+    
     # If this is the first report, add the user's first member list to it
     member_list = (
         model_types.ExternalDataSource.get_queryset(
@@ -178,9 +181,8 @@ def create_map_report(info: Info, data: MapReportInput) -> models.MapReport:
                 "visible": True,
             }
         ]
-        map_report.save()
+    map_report.save()
     return map_report
-
 
 def get_or_create_organisation_for_source(info: Info, data: any):
     if data.organisation:


### PR DESCRIPTION

## Description
This PR replaces the timestamp that was the previous default report name with some text 'Type your report name here'

## Motivation and Context
Addresses issue [MEEP-309](https://linear.app/commonknowledge/issue/MEEP-309/generate-a-nice-random-report-name)

## How Can It Be Tested?
Download branch and run locally
Navigate to http://localhost:3000/reports and click create new report
Observe the new default name

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)