### PR TITLE
Hub maps can have arbitrary layer filters (e.g. only published=true)

### DIFF
--- a/hub/cache_keys.py
+++ b/hub/cache_keys.py
@@ -1,0 +1,2 @@
+def site_tile_filter_dict(hostname: str, external_data_source_id: str, *args, **kwargs):
+    return f"site_tile_filter:{hostname}:{external_data_source_id}"

--- a/hub/graphql/types/model_types.py
+++ b/hub/graphql/types/model_types.py
@@ -542,11 +542,18 @@ class Area:
     def generic_data_for_hub(self, hostname: str) -> List["GenericData"]:
         site = Site.objects.get(hostname=hostname)
         hub = site.root_page.specific
-        source_ids = [layer.get("source") for layer in hub.layers]
-        return models.GenericData.objects.filter(
-            data_type__data_set__external_data_source__in=source_ids,
-            point__within=self.polygon,
-        )
+        data = []
+        for layer in hub.layers:
+            data.extend(
+                models.GenericData.objects.filter(
+                    data_type__data_set__external_data_source=layer.get("source"),
+                    data_type__data_set__external_data_source__can_display_points_publicly=True,
+                    data_type__data_set__external_data_source__can_display_details_publicly=True,
+                    point__within=self.polygon,
+                    **layer.get("filter", {})
+                )
+            )
+        return data
 
 
 @strawberry.type

--- a/hub/models.py
+++ b/hub/models.py
@@ -1471,14 +1471,13 @@ class ExternalDataSource(PolymorphicModel, Analytics):
         ]
 
     @classmethod
-    def _get_import_data(self, id: str, filter = {}):
+    def _get_import_data(self, id: str):
         """
         For use by views to query data without having to instantiate the class / query the database for the CRM first
         """
         logger.debug(f"getting import data where external data source id is {id}")
         return GenericData.objects.filter(
-            data_type__data_set__external_data_source_id=id,
-            **(filter or {})
+            data_type__data_set__external_data_source_id=id
         )
 
     def get_import_data(self):

--- a/hub/views/vector_tiles.py
+++ b/hub/views/vector_tiles.py
@@ -42,7 +42,9 @@ class GenericDataVectorLayer(VectorLayer):
         super().__init__(*args, **kwargs)
 
     def get_queryset(self) -> QuerySet:
-        return ExternalDataSource._get_import_data(self.external_data_source_id, self.filter)
+        return ExternalDataSource\
+            ._get_import_data(self.external_data_source_id)\
+            .filter(**self.filter)
 
 
 class ExternalDataSourceTileView(MVTView, DetailView):

--- a/hub/views/vector_tiles.py
+++ b/hub/views/vector_tiles.py
@@ -9,7 +9,11 @@ from gqlauth.core.middlewares import UserOrError, get_user_or_error
 from vectortiles import VectorLayer
 from vectortiles.views import MVTView, TileJSONView
 
-from hub.models import ExternalDataSource, GenericData
+from hub.models import ExternalDataSource, GenericData, HubHomepage
+from wagtail.models import Site
+from utils.cached_fn import cached_fn
+from utils.url import get_hostname_from_url
+from hub.cache_keys import site_tile_filter_dict
 
 logger = logging.getLogger(__name__)
 
@@ -27,14 +31,18 @@ class GenericDataVectorLayer(VectorLayer):
     layer_fields = tile_fields
     vector_tile_fields = layer_fields
 
+    external_data_source_id: str
+    filter: dict = {}
+
     def __init__(self, *args, **kwargs):
         self.external_data_source_id = kwargs.pop("external_data_source_id", None)
         if self.external_data_source_id is None:
             raise ValueError("external_data_source is required")
+        self.filter = kwargs.pop("filter", {})
         super().__init__(*args, **kwargs)
 
     def get_queryset(self) -> QuerySet:
-        return ExternalDataSource._get_import_data(self.external_data_source_id)
+        return ExternalDataSource._get_import_data(self.external_data_source_id, self.filter)
 
 
 class ExternalDataSourceTileView(MVTView, DetailView):
@@ -64,8 +72,31 @@ class ExternalDataSourceTileView(MVTView, DetailView):
         return self.kwargs.get(self.pk_url_kwarg)
 
     def get_layer_class_kwargs(self, *args, **kwargs):
-        return {"external_data_source_id": self.get_id()}
+        external_data_source_id = self.get_id()
+        return {
+            "external_data_source_id": external_data_source_id,
+            "filter": self.get_site_filter(
+                get_hostname_from_url(self.request.headers.get("Referer")),
+                external_data_source_id
+            )
+        }
 
+    @cached_fn(key=lambda a, hostname, id: site_tile_filter_dict(hostname, id), timeout_seconds=100000, cache_type="default")
+    def get_site_filter(self, hostname: str, external_data_source_id: str):
+        '''
+        Obey hub-level layer filtering logic.
+        '''
+        logger.debug("getting filter", hostname, external_data_source_id)
+        site = Site.objects.filter(hostname=hostname).first()
+        if site is not None:
+            hub: HubHomepage = site.root_page.specific
+            layers = hub.get_layers()
+            logger.debug("filter in layers", layers)
+            if isinstance(layers, list):
+                for layer in layers:
+                    if layer.get("source") == external_data_source_id:
+                        return layer.get("filter", {})
+        return {}
 
 class ExternalDataSourcePointTileJSONView(TileJSONView, DetailView):
     model = ExternalDataSource

--- a/utils/url.py
+++ b/utils/url.py
@@ -1,0 +1,8 @@
+from urllib.parse import urlparse
+
+def get_hostname_from_url(url: str) -> str:
+    '''
+    E.g. http://united.localhost:3000/blah -> united.localhost
+    '''
+    parsed = urlparse(url)
+    return parsed.hostname


### PR DESCRIPTION
Adds data filtering support for hubs.

## Description
- Adds `filter` key to the `MapLayer` dict
- Implements data source (GenericData) filtering for hub tile / graphql queries

This PR doesn't handle filtering for private reports.

## Motivation and Context

TCC wants to display only events that have been published on the public map. This PR adds filtering logic at the level of the hub.

An alternative approach might have been to add filtering logic at the level of the external data source, to apply to all queries — including private reports — but that seemed too presumptuous. Private reports might have their own filtering logic.

## How Can It Be Tested?

- Add a filter key to the layer
- Look at the hub map and note whether the markers and event listings comply

## How Will This Be Deployed?

N/A

## Screenshots (if appropriate):

<img width="628" alt="Screenshot 2024-05-31 at 00 01 07" src="https://github.com/commonknowledge/meep-intelligence-hub/assets/237556/3a262992-716e-4584-8e70-8b376611604b">

## Types of changes
- [X] New feature (non-breaking change which adds functionality)